### PR TITLE
Update README.md Broken Link To Anaconda Download

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Keras-TensorFlow-GPU-Windows-Installation
 10 easy steps on the installation of TensorFlow-GPU and Keras in Windows
 
-### Step 1: Install Anaconda (Python 3.6 version) <a href="https://www.continuum.io/downloads" target="_blank">Download</a>
+### Step 1: Install Anaconda (Python 3.6 version) <a href="https://www.anaconda.com/download/" target="_blank">Download</a>
 <p align="center"><img width=70% src="https://github.com/antoniosehk/keras-tensorflow-windows-installation/blob/master/anaconda_windows_installation.png"></p>
 
 ### Step 2: Update Anaconda


### PR DESCRIPTION
https://continuum.io redirects to https://www.anaconda.com/ so the site URL has probably been updated. Readme.md has been updated with this PR to point to the correct Anaconda download location. 